### PR TITLE
Include and enable xsendfile

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,24 @@
+turnkey-avideo-18.2 (1) turnkey; urgency=low
+
+  * v18.1 rebuild - includes latest Debian & TurnKey packages.
+
+  * Update Avideo to latest upsteam - v14.3.
+
+  * Include and enable Apache xsendfile module - closes #1966.
+
+  * Configuration console (confconsole) - v2.1.6:
+    - Let's Encrypt/Dehydrated - bugfix cron failure - closes #1962.
+    - General dehydrated-wrapper code cleanup - now passes shellcheck.
+
+  * Reduce log noise by creating ntpsec log dir - closes #1952.
+
+  * Apache mod_evasive config improvements:
+    - Bump DOSPageCount from (default) 2 -> 5 - closes #1951.
+    - DOSLogDir - use default log dir & fix permissions - closes #1950.
+    - Add DOSWhitelist example - commented out.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Fri, 05 Jul 2024 11:04:36 +0000
+
 turnkey-avideo-18.1 (1) turnkey; urgency=low
 
   * Update Avideo to latest upstream (git repo master) - v12.4.

--- a/conf.d/main
+++ b/conf.d/main
@@ -29,7 +29,7 @@ sed -i "s|^max_execution.*|max_execution_time = 21600|" $PHPINI
 systemctl enable avideo-streamchat.service
 cat > /etc/apache2/mods-available/proxy.conf << EOF
 <IfModule mod_proxy.c>
-        ProxyPass /wss/ ws://127.0.0.1:8888/
+    ProxyPass /wss/ ws://127.0.0.1:8888/
 </IfModule>
 EOF
 
@@ -39,6 +39,7 @@ a2ensite avideo
 a2ensite avideo-encoder
 a2enmod proxy_wstunnel
 a2enmod rewrite
+a2enmod xsendfile
 
 # clone repos and create required dirs
 GH_URL=https://github.com/WWBN

--- a/overlay/etc/apache2/sites-available/avideo.conf
+++ b/overlay/etc/apache2/sites-available/avideo.conf
@@ -21,8 +21,9 @@ ServerName localhost
 </VirtualHost>
 
 <Directory /var/www/avideo/>
-    Options +FollowSymLinks
-    Options -Indexes
+    Options Indexes FollowSymLinks
+    XSendFile on
+    XSendFilePath /var/www/avideo/
     AllowOverride All
     Require all granted
 </Directory>

--- a/plan/main
+++ b/plan/main
@@ -5,6 +5,7 @@ php-curl
 php-gd
 php-intl
 php-xml
+libapache2-mod-xsendfilel
 ffmpeg
 libimage-exiftool-perl
 libjs-cropper


### PR DESCRIPTION
Avideo update.

Closes https://github.com/turnkeylinux/tracker/issues/1966

v18.2 changelog still required - note initial Avideo v18.x release was accidentally versioned v18.1